### PR TITLE
feat(ggentropy) support fallback when syscall getrandom unavailable

### DIFF
--- a/bcrypt-2.4.0-1.rockspec
+++ b/bcrypt-2.4.0-1.rockspec
@@ -1,0 +1,31 @@
+package = "bcrypt"
+version = "2.4.0-1"
+
+source = {
+	url = "git+https://github.com/Kong/lua-bcrypt.git",
+	tag = "2.4.0",
+}
+
+description = {
+	summary = "A Lua wrapper for bcrypt",
+	homepage = "http://github.com/Kong/lua-bcrypt",
+	license = "ISC",
+	maintainer = "Kong Inc.",
+}
+
+dependencies = {
+	"lua >= 5.1",
+}
+
+build = {
+	type = "builtin",
+	modules = {
+		bcrypt = {
+			"src/main.c",
+			"src/bcrypt.c",
+			"src/blowfish.c",
+			"src/ggentropy.c",
+			"src/safebfuns.c",
+		}
+	},
+}

--- a/src/ggentropy.c
+++ b/src/ggentropy.c
@@ -53,12 +53,195 @@ bool ggentropy( void * buf, size_t n ) {
 
 #include <unistd.h>
 #include <sys/syscall.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/random.h>
+
+#ifdef SYS_getrandom
+static int getentropy_getrandom(void *buf, size_t len);
+#endif
+static int getentropy_urandom(void *buf, size_t len);
+#ifdef SYS__sysctl
+static int getentropy_sysctl(void *buf, size_t len);
+#endif
 
 bool ggentropy( void * buf, size_t n ) {
 	assert( n <= 256 );
-	int ok = syscall( SYS_getrandom, buf, n, 0 );
-	return ok >= 0 && ( size_t ) ok == n;
+	int ret;
+
+#ifdef SYS_getrandom
+	static bool getrandom_available = true;
+
+	if (getrandom_available) {
+		/*
+		 * Try descriptor-less getrandom()
+		 */
+		ret = getentropy_getrandom(buf, n);
+		if (ret != -1)
+			return true;
+
+		if (errno == ENOSYS) {
+			getrandom_available = false;
+		}
+		else {
+			return false;
+		}
+	}
+#endif
+
+	/*
+	 * Try to get entropy with /dev/urandom
+	 *
+	 * This can fail if the process is inside a chroot or if file
+	 * descriptors are exhausted.
+	 */
+	ret = getentropy_urandom(buf, n);
+	if (ret != -1)
+		return true;
+
+#ifdef SYS__sysctl
+	/*
+	 * Try to use sysctl CTL_KERN, KERN_RANDOM, RANDOM_UUID.
+	 * sysctl is a failsafe API, so it guarantees a result.  This
+	 * should work inside a chroot, or when file descriptors are
+	 * exhuasted.
+	 *
+	 * However this can fail if the Linux kernel removes support
+	 * for sysctl.  Starting in 2007, there have been efforts to
+	 * deprecate the sysctl API/ABI, and push callers towards use
+	 * of the chroot-unavailable fd-using /proc mechanism --
+	 * essentially the same problems as /dev/urandom.
+	 *
+	 * Numerous setbacks have been encountered in their deprecation
+	 * schedule, so as of June 2014 the kernel ABI still exists on
+	 * most Linux architectures. The sysctl() stub in libc is missing
+	 * on some systems.  There are also reports that some kernels
+	 * spew messages to the console.
+	 */
+	ret = getentropy_sysctl(buf, n);
+	if (ret != -1)
+		return true;
+#endif /* SYS__sysctl */
+
+	return false;
 }
+
+#ifdef SYS_getrandom
+static int
+getentropy_getrandom(void *buf, size_t len)
+{
+	int pre_errno = errno;
+	int ret;
+	unsigned char *p = buf;
+	int left = len;
+
+	while (left > 0) {
+		ret = syscall(SYS_getrandom, p, left, 0);
+		if (ret == -1) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+
+		left -= ret;
+		p += ret;
+	}
+
+	errno = pre_errno;
+	return (0);
+}
+#endif
+
+static int
+getentropy_urandom(void *buf, size_t len)
+{
+	struct stat st;
+	size_t i;
+	int fd, cnt, flags;
+	int save_errno = errno;
+
+start:
+
+	flags = O_RDONLY;
+#ifdef O_NOFOLLOW
+	flags |= O_NOFOLLOW;
+#endif
+#ifdef O_CLOEXEC
+	flags |= O_CLOEXEC;
+#endif
+	fd = open("/dev/urandom", flags, 0);
+	if (fd == -1) {
+		if (errno == EINTR)
+			goto start;
+		goto nodevrandom;
+	}
+#ifndef O_CLOEXEC
+	fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC);
+#endif
+
+	/* Lightly verify that the device node looks sane */
+	if (fstat(fd, &st) == -1 || !S_ISCHR(st.st_mode)) {
+		close(fd);
+		goto nodevrandom;
+	}
+	if (ioctl(fd, RNDGETENTCNT, &cnt) == -1) {
+		close(fd);
+		goto nodevrandom;
+	}
+	for (i = 0; i < len; ) {
+		size_t wanted = len - i;
+		ssize_t ret = read(fd, (char *)buf + i, wanted);
+
+		if (ret == -1) {
+			if (errno == EAGAIN || errno == EINTR)
+				continue;
+			close(fd);
+			goto nodevrandom;
+		}
+		i += ret;
+	}
+	close(fd);
+
+	errno = save_errno;
+	return 0;
+
+nodevrandom:
+	errno = EIO;
+	return -1;
+}
+
+#ifdef SYS__sysctl
+static int
+getentropy_sysctl(void *buf, size_t len)
+{
+	static int mib[] = { CTL_KERN, KERN_RANDOM, RANDOM_UUID };
+	size_t i;
+	int save_errno = errno;
+
+	for (i = 0; i < len; ) {
+		size_t chunk = min(len - i, 16);
+
+		/* SYS__sysctl because some systems already removed sysctl() */
+		struct __sysctl_args args = {
+			.name = mib,
+			.nlen = 3,
+			.oldval = (char *)buf + i,
+			.oldlenp = &chunk,
+		};
+		if (syscall(SYS__sysctl, &args) != 0)
+			goto sysctlfailed;
+		i += chunk;
+	}
+
+	errno = save_errno;
+	return 0;
+sysctlfailed:
+	errno = EIO;
+	return -1;
+}
+#endif /* SYS__sysctl */
 
 #elif PLATFORM_HAS_ARC4RANDOM
 


### PR DESCRIPTION
lua-bcrypt use system call `SYS_getrandom` to get entropy,
which is not available when linux kernel is lower than 3.17.

Since the author doesn't want to support low kernel version anymore,
we use our own fork to add fallback mechanism.

associated PRs:
https://github.com/Kong/kong-ee/pull/3810
https://github.com/Kong/kong-distributions/pull/805

FTI-4303